### PR TITLE
Variable Arity

### DIFF
--- a/lib/minitest/fire_mock.rb
+++ b/lib/minitest/fire_mock.rb
@@ -17,7 +17,7 @@ class MiniTest::FireMock < MiniTest::Mock
 
     if method
       if variable_arity?(method) and args.size > method.arity.abs
-        raise MockExpectationError, "`#{name}` expects 0..#{abs(method.arity)} arguments, given #{args.size}"
+        raise MockExpectationError, "`#{name}` expects 0..#{method.arity.abs} arguments, given #{args.size}"
       elsif !variable_arity?(method) and method.arity != args.size
         raise MockExpectationError, "`#{name}` expects #{method.arity} arguments, given #{args.size}"
       end

--- a/lib/minitest/fire_mock.rb
+++ b/lib/minitest/fire_mock.rb
@@ -10,12 +10,17 @@ class MiniTest::FireMock < MiniTest::Mock
 
   def expect(name, retval, args = [])
     method = @constant.instance_method(name) rescue nil
+
     if @constant and not method
       raise MockExpectationError, "expected #{@constant_name} to define `#{name}`, but it doesn't"
     end
 
-    if method and method.arity != args.size
-      raise MockExpectationError, "`#{name}` expects #{method.arity} arguments, given #{args.size}"
+    if method
+      if variable_arity?(method) and args.size > method.arity.abs
+        raise MockExpectationError, "`#{name}` expects 0..#{abs(method.arity)} arguments, given #{args.size}"
+      elsif !variable_arity?(method) and method.arity != args.size
+        raise MockExpectationError, "`#{name}` expects #{method.arity} arguments, given #{args.size}"
+      end
     end
 
     super(name, retval, args)
@@ -23,6 +28,10 @@ class MiniTest::FireMock < MiniTest::Mock
 
   private
   # Borrowed from ActiveSupport.
+  def variable_arity?(method)
+    method.arity < 0
+  end
+
   def constantize(camel_cased_word)
     names = camel_cased_word.split('::')
     names.shift if names.empty? || names.first.empty?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ MiniTest::Unit.autorun
 
 class DefinedConstant
   def defined_method; end
+
+  def variable_arity_method(optional=nil); end
 end
 
 module Namespace

--- a/test/unit/firemock_test.rb
+++ b/test/unit/firemock_test.rb
@@ -51,17 +51,24 @@ class FireMockTest < MiniTest::Unit::TestCase
     end
   end
 
-  def test_valid_mock_with_variable_arity_used
+  def test_valid_mock_with_optional_param_present
     mock = MiniTest::FireMock.new('DefinedConstant')
     mock.expect(:variable_arity_method, 42, [5])
     assert_equal 42, mock.variable_arity_method(5)
     mock.verify
   end
 
-  def test_valid_mock_with_variable_arity_unused
+  def test_valid_mock_with_optional_param_absent
     mock = MiniTest::FireMock.new('DefinedConstant')
     mock.expect(:variable_arity_method, 42)
     assert_equal 42, mock.variable_arity_method
     mock.verify
+  end
+
+  def test_valid_mock_with_too_many_params
+    mock = MiniTest::FireMock.new('DefinedConstant')
+    assert_raises MockExpectationError, "`variable_arity_method` expects 0..1 arguments, given 2" do
+      mock.expect(:variable_arity_method, 42, [6,7])
+    end
   end
 end

--- a/test/unit/firemock_test.rb
+++ b/test/unit/firemock_test.rb
@@ -50,4 +50,18 @@ class FireMockTest < MiniTest::Unit::TestCase
       mock.expect(:defined_method, 42, [1,2,3])
     end
   end
+
+  def test_valid_mock_with_variable_arity_used
+    mock = MiniTest::FireMock.new('DefinedConstant')
+    mock.expect(:variable_arity_method, 42, [5])
+    assert_equal 42, mock.variable_arity_method(5)
+    mock.verify
+  end
+
+  def test_valid_mock_with_variable_arity_unused
+    mock = MiniTest::FireMock.new('DefinedConstant')
+    mock.expect(:variable_arity_method, 42)
+    assert_equal 42, mock.variable_arity_method
+    mock.verify
+  end
 end


### PR DESCRIPTION
Variable method arity, like the following fails the expectation match:

```ruby
def variable_arity(opt={})
```

Fails with `MockExpectationError: `variable_arity` expects -1 arguments, given 1` when argument provide, fails with `MockExpectationError: `variable_arity` expects -1 arguments, given 0` when left out.

This is because `UnboundMethod` (returned by `@const.instance_method(:method_name)` here: https://github.com/cfcosta/minitest-firemock/blob/master/lib/minitest/fire_mock.rb#L12) returns `-n-1` for arguments where `n` equals the number of **required** arguments. See method `arity` under http://ruby-doc.org/core-2.2.0/UnboundMethod.html
