### PR TITLE
Update minitest conventions

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,4 @@
-require 'minitest/unit'
-
-MiniTest::Unit.autorun
+require 'minitest/autorun'
 
 class DefinedConstant
   def defined_method; end

--- a/test/unit/firemock_test.rb
+++ b/test/unit/firemock_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'minitest/fire_mock'
 
-class FireMockTest < MiniTest::Unit::TestCase
+class FireMockTest < Minitest::Test
   def test_mock_is_valid_when_not_defined
     mock = MiniTest::FireMock.new('NotDefinedConstant')
     mock.expect(:defined_method, 42)


### PR DESCRIPTION
Some deprecation warnings occurring. Suppose this depends on what version of ruby/minitest you want to support, but opening anyways.