### PR TITLE
Bad constant lookups when inheritance chain is messy/poluted

### DIFF
--- a/lib/minitest/fire_mock.rb
+++ b/lib/minitest/fire_mock.rb
@@ -39,7 +39,7 @@ class MiniTest::FireMock < MiniTest::Mock
 
     names.inject(Object) do |constant, name|
       next constant.const_get(name) if constant == Object
-      constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
+      constant.const_defined?(name) ? constant.const_get(name, false) : constant.const_missing(name)
     end
 
   rescue NameError

--- a/lib/minitest/fire_mock.rb
+++ b/lib/minitest/fire_mock.rb
@@ -27,20 +27,21 @@ class MiniTest::FireMock < MiniTest::Mock
   end
 
   private
-  # Borrowed from ActiveSupport.
+
   def variable_arity?(method)
     method.arity < 0
   end
 
+  # Borrowed from ActiveSupport.
   def constantize(camel_cased_word)
     names = camel_cased_word.split('::')
     names.shift if names.empty? || names.first.empty?
 
-    constant = Object
-    names.each do |name|
-      constant = constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
+    names.inject(Object) do |constant, name|
+      next constant.const_get(name) if constant == Object
+      constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
     end
-    constant
+
   rescue NameError
     nil
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,4 +10,12 @@ module Namespace
   class NamespacedConstant
     def defined_method; end
   end
+
+  class OtherConstant < NamespacedConstant
+    def world; end
+  end
+end
+
+module OtherConstant
+  def hello; end
 end

--- a/test/unit/firemock_test.rb
+++ b/test/unit/firemock_test.rb
@@ -44,6 +44,8 @@ class FireMockTest < MiniTest::Test
     end
   end
 
+  # TODO: Make sure this test works as expected.
+  # Right now it is passing when it shouldn't be (at least while isolated).
   def test_mock_with_namespace_mocks_correct_const
     mock = Minitest::FireMock.new('Namespace::OtherConstant')
     mock.expect(:world, 42)
@@ -53,6 +55,8 @@ class FireMockTest < MiniTest::Test
     mock.verify
   end
 
+  # TODO: Make sure this test works as expected.
+  # Right now it is passing when it shouldn't be (at least while isolated).
   def test_mock_with_const_mocks_correct_const
     mock = Minitest::FireMock.new('OtherConstant')
     mock.expect(:hello, 42)

--- a/test/unit/firemock_test.rb
+++ b/test/unit/firemock_test.rb
@@ -44,6 +44,24 @@ class FireMockTest < MiniTest::Test
     end
   end
 
+  def test_mock_with_namespace_mocks_correct_const
+    mock = Minitest::FireMock.new('Namespace::OtherConstant')
+    mock.expect(:world, 42)
+
+    assert_raises(MockExpectationError) { mock.expect(:hello, 42) }
+    assert_equal 42, mock.world
+    mock.verify
+  end
+
+  def test_mock_with_const_mocks_correct_const
+    mock = Minitest::FireMock.new('OtherConstant')
+    mock.expect(:hello, 42)
+
+    assert_raises(MockExpectationError) { mock.expect(:world, 42) }
+    assert_equal 42, mock.hello
+    mock.verify
+  end
+
   def test_valid_mock_with_different_arity
     mock = MiniTest::FireMock.new('DefinedConstant')
     assert_raises MockExpectationError, "`defined_method` expects 0 arguments, given 3" do


### PR DESCRIPTION
This may be something caused by Rails messing with the lookup chain or something, because I can't reproduce this standalone test suite, but our `constantize` method is pulling in root-level constants, even when the constant is found inside of a namespace. So `constantize('MyThing::AConstant')` will return `::AConstant` if `AConstant` is also defined at the root level. I did this for something like the following:

``` ruby
require 'stripe'

class BillingService::Stripe
  # special handling...

  def charge
    # code...
  end
end

```

The Stripe library declares a module of `Stripe` at the root namespace level. Doing the following yields an error:

``` ruby
mock = Minitest::Firemock.new('BillingService::Stripe')
mock.expect(:charge, true)

```

Digging revealed that the `constantize` method was returning the root-level `Stripe` constant. While I can't prove a failure and a fix, I can prove that nothing breaks :) Tests added to confirm. Hopefully that's good enough.
